### PR TITLE
Added build system files, updated README, and fixed ST3 issue

### DIFF
--- a/.no-sublime-package
+++ b/.no-sublime-package
@@ -1,0 +1,1 @@
+.no-sublime-package

--- a/Sass — Compact.sublime-build
+++ b/Sass — Compact.sublime-build
@@ -1,0 +1,18 @@
+{
+
+	"cmd": ["sass", "--update", "$file:${file_path}/${file_base_name}.css", "--stop-on-error", "--no-cache", "--style", "compact"],
+
+	"selector": "source.sass, source.scss",
+	"line_regex": "Line ([0-9]+):",
+
+	"osx":
+	{
+		"path": "/usr/local/bin:$PATH"
+	},
+
+	"windows":
+	{
+		"shell": "true"
+	}
+
+}

--- a/Sass — Compressed.sublime-build
+++ b/Sass — Compressed.sublime-build
@@ -1,0 +1,18 @@
+{
+
+	"cmd": ["sass", "--update", "$file:${file_path}/${file_base_name}.css", "--stop-on-error", "--no-cache", "--style", "compressed"],
+
+	"selector": "source.sass, source.scss",
+	"line_regex": "Line ([0-9]+):",
+
+	"osx":
+	{
+		"path": "/usr/local/bin:$PATH"
+	},
+
+	"windows":
+	{
+		"shell": "true"
+	}
+
+}

--- a/Sass — Expanded.sublime-build
+++ b/Sass — Expanded.sublime-build
@@ -1,0 +1,18 @@
+{
+
+	"cmd": ["sass", "--update", "$file:${file_path}/${file_base_name}.css", "--stop-on-error", "--no-cache", "--style", "expanded"],
+
+	"selector": "source.sass, source.scss",
+	"line_regex": "Line ([0-9]+):",
+
+	"osx":
+	{
+		"path": "/usr/local/bin:$PATH"
+	},
+
+	"windows":
+	{
+		"shell": "true"
+	}
+
+}

--- a/Sass — Nested.sublime-build
+++ b/Sass — Nested.sublime-build
@@ -1,0 +1,17 @@
+{
+
+	"cmd": ["sass", "--update", "$file:${file_path}/${file_base_name}.css", "--stop-on-error", "--no-cache"],
+	"selector": "source.sass, source.scss",
+	"line_regex": "Line ([0-9]+):",
+
+	"osx":
+	{
+		"path": "/usr/local/bin:$PATH"
+	},
+
+	"windows":
+	{
+		"shell": "true"
+	}
+
+}

--- a/readme.md
+++ b/readme.md
@@ -1,39 +1,47 @@
-SASS build system for Sublime Text 2
-====================================
+Sass build system for Sublime Text
+==================================
 
-**Note: I'm working in a portable version of the SASS build with all the libraries included & ready to use. It will be available (I hope!) the next week.**
 
 Description
 -----------
 
-Provides two Build system for SASS files (with and without compression)
+This is a plugin for Sublime Text 2/3 providing four build systems for Sass/SCSS files:
+ * `Nested` (default)
+ * `Compressed`
+ * `Compact`
+ * `Expanded`
+
 
 
 Prerequisites
 -------------
 
-Requires **Ruby** & **SASS** libraries.
+Requires **Ruby** & **Sass** libraries.
 
-Step by step:
+####Step-by-step library installation guide: 
+---
 
 1. Install Ruby library
 
-	**Windows**: Download and install Ruby. You can find it here:
-	http://rubyinstaller.org/downloads/
+	**Windows**: Download and install Ruby. You can find it here: http://rubyinstaller.org/downloads/
 
-	Reboot after install it.
+	Reboot after installing it.
 
 	**IMPORTANT**: Don't forget to mark the option '*Add Ruby executables to your PATH*'.
-	If you don't check the option, you will have to modify the path in the Build file afterwards.
+	If you don't check this option, you will have to modify the path in the Build file afterwards.
 
 	**OS X & Linux**: It's already installed. Easy! :)
 
 
-2. Installing SASS
+2. Installing Sass
 
-	Open your console ('*Command prompt with Ruby*' on Windows) and execute the following command:
+	Open your console (_`Command prompt with Ruby`_ on Windows or _`Terminal`_ on Mac) and execute the following command:
 
 	`gem install sass`
+
+	Depending on your user permissions, the above command may not work. If that is the case, try executing this command:
+
+	`sudo gem install sass`
 
 
 Installing
@@ -46,9 +54,9 @@ The easiest way to install this package is through Package Control.
 Follow the instructions on the website.
 
 2. Open the command panel: `Control+Shift+P` (Linux/Windows) or `Command+Shift+P` (OS X) and select '**Package Control: Install Package**'.
-3. When the packages list appears type '**SASS**' and you'll find the **SASS Build System**. Select to install it.
+3. When the packages list appears type '**Sass**' and you'll find the **Sass Build System**. Select to install it.
 
-4. Now you can compile your SASS files! Launch your build with `Control+B` (Linux/Windows) or `Command+B` (OS X).
+4. Now you can compile your Sass files! Launch your build with `Control+B` (Linux/Windows) or `Command+B` (OS X).
 
 5. Enjoy your coding =)
 
@@ -57,28 +65,31 @@ Follow the instructions on the website.
 
 Clone the repository in your Sublime Text "Packages" directory:
 
-    git clone git://https://github.com/jaumefontal/SASS-Build-SublimeText2.git SASS-build
+    git clone git://github.com/jaumefontal/Sass-Build-SublimeText2.git Sass-build
 
-You can find your 'Packages' inside the following directories:
+Depending on your version of Sublime Text, you can find your 'Packages' inside the following directories:
 
 * OS X:
     `~/Library/Application Support/Sublime Text 2/Packages/`
+    `~/Library/Application Support/Sublime Text 3/Packages/`
 * Windows:
     `%APPDATA%/Sublime Text 2/Packages/`
+    `%APPDATA%/Sublime Text 3/Packages/`
 * Linux:
     `~/.Sublime Text 2/Packages/`
+    `~/.Sublime Text 3/Packages/`
 
 **OPTION 3 - Without Git**
 
-Download the latest source zip from [Github](https://github.com/jaumefontal/SASS-Build-SublimeText2) and extract it into a new folder named `SASS-Build` in your Sublime Text "Packages" folder.
+Download the latest source zip from [Github](https://github.com/jaumefontal/Sass-Build-SublimeText2) and extract it into a new folder named `Sass-Build` in your Sublime Text "Packages" folder.
 
 
 Using the build
 ---------------
 
-After installing the package you will find two new options in `Tools > Build system` of your  Sublime menu: **SASS** and **SASS - Compressed**.
+After installing the package you will find four new options in `Tools > Build system` option in your Sublime menu: `Sass — Nested`, `Sass - Compressed`,  `Sass — Expanded`, and `Sass - Compact`.
 
-By default your `.scss` and `.sass` files will be built using the **SASS build** (not compressed).
+By default, your `.scss` and `.sass` files will be built using the **Sass — Nested** setting. Additionally, the files will be saved into the same directory as the Sass file. For information on how to change this setting, please see the **Recommendations** section below.
 
 And remember, always you can launch the selected build with `Control+B` (Linux/Windows) or `Command+B` (OS X).
 
@@ -86,12 +97,23 @@ And remember, always you can launch the selected build with `Control+B` (Linux/W
 Recommendations
 ---------------
 
-* Is recommended to use this build with one of the next plugins: [SASS plugin](https://github.com/nathos/sass-textmate-bundle) or [SCSS.tmbundle](https://github.com/kuroir/SCSS.tmbundle).
-* Also, I recommend the plugin [SublimeOnSaveBuild](https://github.com/alexnj/SublimeOnSaveBuild). Just save your SASS files and transform them into CSS!
-* If you want to change the default folder of your generated CSS files into another one, you can edit the build:
+* This plugin will work best when combined with either the [Sass plugin](https://github.com/nathos/sass-textmate-bundle) or [SCSS.tmbundle](https://github.com/kuroir/SCSS.tmbundle).
+* Also, I recommend the plugin [SublimeOnSaveBuild](https://github.com/alexnj/SublimeOnSaveBuild). When you save your Sass files, they will transformed into CSS!
+
+####Changing the default folder for generated CSS
+
+If you want to change the default folder of where your CSS is generated, you can edit the `.sublime-build` files, found in the `Sass-build` folder of the 'Packages' directory. In Sublime Text 3, you can easily access this directory through the `Preferences > Browse Packages` option in the Sublime menu:
 
   **Example:** Save your CSS files into a `css` folder:
   `"cmd": ["sass", "--update", "$file:${file_path}/../css/${file_base_name}.css"],`
+
+  If you are using partials and running into issues, David Kiv [suggests](http://blog.hovercraft.ie/post/61592756918/update-sass-build-plug-in-for-sublime-text-2-to) putting this code in the `.sublime-build` files:
+
+  **Windows** 
+  	* `"cmd": ["sass", "--update", "${project_path}\\scss\\styles.scss:${project_path}\\css\\styles.css", "--stop-on-error", "--no-cache"],`
+  **Mac** 
+    * `"cmd": ["sass", "--update", "${project_path}/scss/styles.scss:${project_path}/css/styles.css", "--stop-on-error", "--no-cache"],`
+
 
 
 Author

--- a/readme.md
+++ b/readme.md
@@ -110,9 +110,10 @@ If you want to change the default folder of where your CSS is generated, you can
   If you are using partials and running into issues, David Kiv [suggests](http://blog.hovercraft.ie/post/61592756918/update-sass-build-plug-in-for-sublime-text-2-to) putting this code in the `.sublime-build` files:
 
   **Windows** 
-  	* `"cmd": ["sass", "--update", "${project_path}\\scss\\styles.scss:${project_path}\\css\\styles.css", "--stop-on-error", "--no-cache"],`
+  		* `"cmd": ["sass", "--update", "${project_path}\\scss\\styles.scss:${project_path}\\css\\styles.css", "--stop-on-error", "--no-cache"],`
+  		
   **Mac** 
-    * `"cmd": ["sass", "--update", "${project_path}/scss/styles.scss:${project_path}/css/styles.css", "--stop-on-error", "--no-cache"],`
+	 * `"cmd": ["sass", "--update", "${project_path}/scss/styles.scss:${project_path}/css/styles.css", "--stop-on-error", "--no-cache"],`
 
 
 


### PR DESCRIPTION
Added build system files for the Compact and Expanded outputs in Sass, updated (and rewrote) the README, and added a `.no-sublime-package` file to fix issue with the Sass Build plugin existing as an unzipped `sublime-package` when installed in Sublime Text 3.
